### PR TITLE
feat: detect trailing newline character

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,3 +12,4 @@ What snyk-try-require does:
 - Adds `__filename` containing the full original path to the package
 - If a Snyk policy is present, will add the path of the policy to the `snyk` property
 - If the package uses `npm-shrinkwrap.json` will include a `shrinkwrap` boolean property
+- Returns the `leading` and `trailing` whitespace of the original `package.json` file as a `leading` and `trailing` property respectively

--- a/lib/try-require.js
+++ b/lib/try-require.js
@@ -22,7 +22,12 @@ function tryRequire(filename) {
     return Promise.resolve(res);
   }
   return fs.readFile(filename, 'utf8')
-    .then(JSON.parse)
+    .then(function (pkgStr) {
+      var pkg = JSON.parse(pkgStr);
+      pkg.leading = pkgStr.match(/^(\s*){/)[1];
+      pkg.trailing = pkgStr.match(/}(\s*)$/)[1];
+      return pkg;
+    })
     .catch(function (e) {
       debug('tryRequire silently failing on %s', e.message);
       return null;

--- a/test/try-require.test.js
+++ b/test/try-require.test.js
@@ -33,6 +33,23 @@ test('try npm-shrinkwrap detect', function (t) {
   }).catch(t.threw).then(t.end);
 });
 
+test('try package with no leading, newline trailing', function (t) {
+  var location = 'node_modules/@remy/snyk-shrink-test';
+
+  var exists = fs.existsSync(location);
+
+  if (!exists) {
+    location = 'node_modules/snyk-resolve-deps-fixtures/node_modules/@remy/snyk-shrink-test';
+  }
+
+  var filename = path.resolve(__dirname, '..', location, 'package.json');
+  tryRequire(filename).then(function (res) {
+    t.notEqual(res, null, 'package was found');
+    t.equal(res.leading, '', 'leading is empty string');
+    t.equal(res.trailing, '\n', 'trailing is newline');
+  }).catch(t.threw).then(t.end);
+});
+
 
 test('try successful require and cached response', function (t) {
   var filename = path.resolve(__dirname, '..',


### PR DESCRIPTION
- [ ] Reviewed by @darscan 

Returns the `leading` and `trailing` whitespace of the original `package.json` file