### PR TITLE
chore: downgrade sem-rel for :sparkles: on travis

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "snyk-resolve-deps-fixtures": "^1.1.5",
     "tap": "^5.5.0",
     "tap-only": "0.0.5",
-    "semantic-release": "^8.0.0"
+    "semantic-release": "^6.0.0"
   },
   "dependencies": {
     "debug": "^3.1.0",


### PR DESCRIPTION
Since we're not building with node8 on travis, sem-rel@8 doesn't do as it is told.