### PR TITLE
Support package.json files that have a UTF-8 BOM

### DIFF
--- a/lib/try-require.js
+++ b/lib/try-require.js
@@ -22,6 +22,12 @@ function tryRequire(filename) {
   }
   return fs.readFile(filename, 'utf8')
     .then(function (pkgStr) {
+      if (pkgStr[0] === '\ufeff') {
+        // String starts with UTF BOM. Remove it so that JSON.parse doesn't
+        // stumble
+        pkgStr = pkgStr.slice(1);
+      }
+
       var pkg = JSON.parse(pkgStr);
       pkg.leading = pkgStr.match(/^(\s*){/)[1];
       pkg.trailing = pkgStr.match(/}(\s*)$/)[1];

--- a/test/fixtures/utf8bom-package.json
+++ b/test/fixtures/utf8bom-package.json
@@ -1,0 +1,6 @@
+﻿{
+  "description": "This file is saved with an UTF-8 BOM.",
+  "main": "lib/index.js",
+  "version": "1",
+  "snyk": true
+}

--- a/test/try-require.test.js
+++ b/test/try-require.test.js
@@ -17,6 +17,14 @@ test('try bare package require', function (t) {
   }).catch(t.threw).then(t.end);
 });
 
+test('try utf8 package require with BOM', function (t) {
+  tryRequire(__dirname + '/fixtures/utf8bom-package.json').then(function (res) {
+    t.notEqual(res, null, 'loaded the package');
+    t.equal(res.name, 'fixtures', 'name was inferred from directory name');
+    t.notEqual(res.dependencies, undefined, 'has dependencies property');
+  }).catch(t.threw).then(t.end);
+});
+
 test('try npm-shrinkwrap detect', function (t) {
   var location = 'node_modules/@remy/snyk-shrink-test';
 


### PR DESCRIPTION
This PR fixes https://github.com/snyk/snyk/issues/81

If you try to require a `package.json` file that start with a UTF-8 BOM, you'll get a crash.

This PR fixes this.