### PR TITLE
fix: replace fixtures repo with committed fixtures

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,0 +1,1 @@
+node_modules/

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,5 @@
 /.nyc_output/
-/node_modules/
+node_modules/
 /coverage
 package-lock.json
 npm-debug.log

--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+package-lock=false

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "env": "node -e 'console.log(process.env, process.versions)'",
     "cover": "tap test/*.test.js --cov --coverage-report=lcov",
     "test": "npm run check-tests && npm run lint && tap test/*.test.js --cov --timeout=60",
+    "postinstall": "npm --prefix test/fixtures/shrink-test-v1 install && npm --prefix test/fixtures/with-policy install",
     "semantic-release": "npx semantic-release@15"
   },
   "repository": {
@@ -23,7 +24,6 @@
   "homepage": "https://github.com/Snyk/try-require#readme",
   "devDependencies": {
     "eslint": "^5.16.0",
-    "snyk-resolve-deps-fixtures": "^1.1.6",
     "tap": "^12.7.0",
     "tap-only": "0.0.5"
   },

--- a/test/fixtures/shrink-test-v1/index.js
+++ b/test/fixtures/shrink-test-v1/index.js
@@ -1,0 +1,2 @@
+// eslint-disable-next-line no-console
+console.log('hello');

--- a/test/fixtures/shrink-test-v1/npm-shrinkwrap.json
+++ b/test/fixtures/shrink-test-v1/npm-shrinkwrap.json
@@ -1,0 +1,34 @@
+{
+  "name": "shrink-test",
+  "version": "1.0.0",
+  "lockfileVersion": 1,
+  "requires": true,
+  "dependencies": {
+    "debug": {
+      "version": "2.6.9",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+      "requires": {
+        "ms": "2.0.0"
+      }
+    },
+    "ms": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+      "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+    },
+    "qs": {
+      "version": "6.9.1",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.9.1.tgz",
+      "integrity": "sha512-Cxm7/SS/y/Z3MHWSxXb8lIFqgqBowP5JMlTUFyJN88y0SGQhVmZnqFK/PeuMX9LzUyWsqqhNxIyg0jlzq946yA=="
+    },
+    "undefsafe": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/undefsafe/-/undefsafe-2.0.2.tgz",
+      "integrity": "sha1-Il9rngM3Zj4Njnz9aG/Cg2zKznY=",
+      "requires": {
+        "debug": "^2.2.0"
+      }
+    }
+  }
+}

--- a/test/fixtures/shrink-test-v1/package.json
+++ b/test/fixtures/shrink-test-v1/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "shrink-test",
+  "version": "1.0.0",
+  "author": "snyk",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "license": "ISC",
+  "main": "index.js",
+  "dependencies": {
+    "qs": "^6.9.1",
+    "undefsafe": "^2.0.2"
+  }
+}

--- a/test/fixtures/with-policy/.npmrc
+++ b/test/fixtures/with-policy/.npmrc
@@ -1,0 +1,1 @@
+package-lock=false

--- a/test/fixtures/with-policy/.snyk
+++ b/test/fixtures/with-policy/.snyk
@@ -1,0 +1,4 @@
+# Snyk (https://snyk.io) policy file, patches or ignores known vulnerabilities.
+version: v1.7.1
+ignore: {}
+patch: {}

--- a/test/fixtures/with-policy/index.js
+++ b/test/fixtures/with-policy/index.js
@@ -1,0 +1,2 @@
+// eslint-disable-next-line no-console
+console.log('hello');

--- a/test/fixtures/with-policy/package.json
+++ b/test/fixtures/with-policy/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "with-policy",
+  "version": "1.0.0",
+  "author": "snyk",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "license": "ISC",
+  "main": "index.js",
+  "dependencies": {
+    "uglify-js": "^3.6.8",
+    "snyk-go-plugin": "1.11.1"
+  }
+}

--- a/test/try-require.test.js
+++ b/test/try-require.test.js
@@ -1,7 +1,6 @@
 const test = require('tap-only');
 const tryRequire = require('../lib/try-require');
 const path = require('path');
-const fs = require('fs');
 
 test('try failure require', function (t) {
   tryRequire('./unknown').then(function (res) {
@@ -27,15 +26,7 @@ test('try utf8 package require with BOM', function (t) {
 });
 
 test('try npm-shrinkwrap detect', function (t) {
-  let location = 'node_modules/@remy/snyk-shrink-test';
-
-  const exists = fs.existsSync(location);
-
-  if (!exists) {
-    location = 'node_modules/snyk-resolve-deps-fixtures/node_modules/@remy/snyk-shrink-test';
-  }
-
-  const filename = path.resolve(__dirname, '..', location, 'package.json');
+  const filename = path.resolve(__dirname, 'fixtures', 'shrink-test-v1', 'package.json');
   tryRequire(filename).then(function (res) {
     t.notEqual(res, null, 'package was found');
     t.equal(res.shrinkwrap, true, 'has and knows about shrinkwrap');
@@ -43,15 +34,7 @@ test('try npm-shrinkwrap detect', function (t) {
 });
 
 test('try package with no leading, newline trailing', function (t) {
-  let location = 'node_modules/@remy/snyk-shrink-test';
-
-  const exists = fs.existsSync(location);
-
-  if (!exists) {
-    location = 'node_modules/snyk-resolve-deps-fixtures/node_modules/@remy/snyk-shrink-test';
-  }
-
-  const filename = path.resolve(__dirname, '..', location, 'package.json');
+  const filename = path.resolve(__dirname, 'fixtures', 'shrink-test-v1', 'package.json');
   tryRequire(filename).then(function (res) {
     t.notEqual(res, null, 'package was found');
     t.equal(res.leading, '', 'leading is empty string');
@@ -61,8 +44,7 @@ test('try package with no leading, newline trailing', function (t) {
 
 
 test('try successful require and cached response', function (t) {
-  const filename = path.resolve(__dirname, '..',
-    'node_modules/snyk-resolve-deps-fixtures/node_modules/uglify-package/package.json');
+  const filename = path.resolve(__dirname, 'fixtures', 'with-policy', 'package.json');
   t.plan(4);
 
   tryRequire(filename).then(function (pkg) {


### PR DESCRIPTION
Copy-paste the two, ~10 line fixtures out of `snyk-resolve-deps-fixtures` and into the repository.

This resolves me continuously hitting errors about `ug-deep` or `@remy/..` when trying to operate `npm` or `travis`.