### PR TITLE
feat: upgrade debug

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "tap-only": "0.0.5"
   },
   "dependencies": {
-    "debug": "^3.1.0",
+    "debug": "^4.1.1",
     "lodash.clonedeep": "^4.3.0",
     "lru-cache": "^4.0.0",
     "then-fs": "^2.0.0"


### PR DESCRIPTION
Old version drops support for node 4 and 5, which doesn't
affect us all that much.