### PR TITLE
feat: upgrade lru-cache (drops node <6)

### DIFF
--- a/lib/try-require.js
+++ b/lib/try-require.js
@@ -4,9 +4,9 @@ const fs = require('then-fs');
 const path = require('path');
 const debug = require('debug')('snyk:resolve:try-require');
 const cloneDeep = require('lodash.clonedeep');
-const lru = require('lru-cache');
+const LRU = require('lru-cache');
 const options = { max: 100, maxAge: 1000 * 60 * 60 };
-const cache = lru(options);
+const cache = new LRU(options);
 
 module.exports.cache = cache; // allows for a reset
 

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
   "dependencies": {
     "debug": "^4.1.1",
     "lodash.clonedeep": "^4.3.0",
-    "lru-cache": "^4.0.0",
+    "lru-cache": "^5.1.1",
     "then-fs": "^2.0.0"
   }
 }


### PR DESCRIPTION
There is no changelog I can find. This is just a rewrite. Options appear to be the same.

https://github.com/isaacs/node-lru-cache/commits/master