### PR TITLE
fix: npm 7 support

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,6 @@
     "env": "node -e 'console.log(process.env, process.versions)'",
     "cover": "tap test/*.test.js --cov --coverage-report=lcov",
     "test": "npm run check-tests && npm run lint && tap test/*.test.js --cov --timeout=60",
-    "postinstall": "npm --prefix test/fixtures/shrink-test-v1 install && npm --prefix test/fixtures/with-policy install",
     "semantic-release": "npx semantic-release@15"
   },
   "repository": {

--- a/test/try-require.test.js
+++ b/test/try-require.test.js
@@ -1,6 +1,17 @@
+const { execFile } = require('child_process');
+const { promisify } = require('util');
+
 const test = require('tap-only');
 const tryRequire = require('../lib/try-require');
 const path = require('path');
+
+const run = promisify(execFile);
+
+test('install assets', async (t) => {
+  await run('npm', ['--prefix', 'test/fixtures/shrink-test-v1', 'install']);
+  await run('npm', ['--prefix', 'test/fixtures/with-policy', 'install']);
+  t.end();
+});
 
 test('try failure require', function (t) {
   tryRequire('./unknown').then(function (res) {


### PR DESCRIPTION
This insane hack (I wrote it) of using `postinstall` to install
test dependencies has finally broken. It causes npm 7 to fail
to install this package in people depending on us.

```
npm ERR! code 254
npm ERR! path /home/faux/code/snyk/whoop/node_modules/snyk-try-require
npm ERR! command failed
npm ERR! command sh -c npm --prefix test/fixtures/shrink-test-v1 install && npm --prefix test/fixtures/with-policy install
npm ERR! npm ERR! code ENOENT
npm ERR! npm ERR! syscall lstat
npm ERR! npm ERR! path /home/faux/code/snyk/whoop/node_modules/snyk-try-require/test
npm ERR! npm ERR! errno -2
npm ERR! npm ERR! enoent ENOENT: no such file or directory, lstat '/home/faux/code/snyk/whoop/node_modules/snyk-try-require/test'
npm ERR! npm ERR! enoent This is related to npm not being able to find a file.
npm ERR! npm ERR! enoent 
npm ERR! 
npm ERR! npm ERR! A complete log of this run can be found in:
```