### PR TITLE
fix(ci): [IGNR-2107] migrate to NPM OIDC trusted publishing

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -7,17 +7,22 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: write  # Required for semantic-release to push tags
 
     steps:
-      - uses: actions/checkout@v2
-      - name: Use Node.js 16
-        uses: actions/setup-node@v2
+      - uses: actions/checkout@v4
         with:
-          node-version: 16
+          fetch-depth: 0  # Required for semantic-release
+      - name: Use Node.js 22
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          registry-url: 'https://registry.npmjs.org'
       - run: npm install
       - run: npm test
       - name: Release
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
         run: npx semantic-release

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "env": "node -e 'console.log(process.env, process.versions)'",
     "cover": "tap test/*.test.js --cov --coverage-report=lcov",
     "test": "npm run check-tests && npm run lint && tap test/*.test.js --cov --timeout=60",
-    "semantic-release": "npx semantic-release@15"
+    "semantic-release": "npx semantic-release"
   },
   "repository": {
     "type": "git",
@@ -17,6 +17,9 @@
   "keywords": [],
   "author": "Remy Sharp",
   "license": "Apache-2.0",
+  "engines": {
+    "node": ">=18"
+  },
   "bugs": {
     "url": "https://github.com/Snyk/try-require/issues"
   },


### PR DESCRIPTION
Follows the Snyk NPM Packages Security Standard and the OIDC Trusted Publishing migration guide.

Jira: https://snyksec.atlassian.net/browse/IGNR-2107
Docs:  
1. https://snyksec.atlassian.net/wiki/spaces/PRODSEC/pages/4767842314/Migrating+NPM+Publishing+to+OIDC+Trusted+Publishing
2. https://snyksec.atlassian.net/wiki/spaces/PRODSEC/pages/4784029774/npm+Packages+Security+Standard